### PR TITLE
Adding footer and support for Cookie Manager

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -198,3 +198,47 @@ a.bg-primary:focus {
         font-size: 1em;
     }
 }
+
+.copyRight {
+    font-size: 12px;
+
+  }
+
+
+.cpy-right {
+
+    text-align: center; 
+
+}
+
+.footer-links {
+    display: flex;
+    justify-content: center; 
+    list-style: none;
+    padding: 0; 
+    flex-wrap: wrap;
+  }
+  
+  .footer-links li {
+    margin: 0 15px; 
+  }
+  
+  .footer-links a {
+    text-decoration: none;
+    transition: color 0.3s;
+    font-size: 12px;
+  }
+  
+  .footer-links a:hover {
+    text-decoration: underline;
+  }
+  
+  /* One Trust Cookie Manager
+  -------------------- */
+  #ot-pc-content, .ot-title-cntr, .ot-pc-footer {
+    font-size: 1.6rem;
+  }
+  
+  #ot-pc-footer {
+    font-size: 1.4rem;
+  }

--- a/index.html
+++ b/index.html
@@ -7,6 +7,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="Tableau open source projects, APIs, documentation and samples hosted on GitHub.">
 
+<!-- OneTrust -->
+<script
+  src="https://a.sfdcstatic.com/enterprise/tableau/prod/2024012/v1/oneTrust/scripttemplates/otSDKStub.js"
+  data-domain-script="2d08f29e-0ede-4e8c-997c-f7ef5be8d4e7"
+  type="text/javascript"
+  charset="UTF-8"
+></script>
+<script type="text/javascript">
+  function OptanonWrapper() {
+    window.addEventListener('load', () => {
+      window.dataLayer.push( { event: 'OneTrustGroupsUpdated' } );
+    });
+  }
+</script>
+
+
+
 <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -150,6 +167,26 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </div>
         </div>
     </div>
+  <!---  {% include footer.html %} -->
+    <!-- Footer -->
+<footer>
+    <hr class="footer-hr">
+    <nav aria-label="Footer Navigation">
+        <ul class="footer-links">
+            <li><a href="https://www.salesforce.com/company/legal/">Legal</a></li>
+            <li><a href="https://www.salesforce.com/company/legal/sfdc-website-terms-of-service/">Terms of Service</a></li>
+            <li><a href="https://www.salesforce.com/company/privacy/">Privacy Information</a></li>
+            <li><a href="https://www.salesforce.com/company/legal/disclosure/">Responsible Disclosure</a></li>
+            <li><a href="https://trust.salesforce.com/">Trust</a></li>
+            <li><a href="#" data-ignore-geolocation="true" class="optanon-toggle-display">Cookie Preferences</a></li>
+            <li><a href="https://www.salesforce.com/form/other/privacy-request/">Your Privacy Choices</a></li>
+        </ul>
+        <div class="cpy-right">
+        <p class="copyRight">&copy; Copyright <script>document.write(new Date().getFullYear())</script> Salesforce, Inc. <a href="https://www.salesforce.com/company/legal/tmcusageguidelines/">All rights reserved.</a> Various trademarks held by their respective owners.
+            Salesforce, Inc. Salesforce Tower, 415 Mission Street, 3rd Floor, San Francisco, CA 94105, United States</p>
+       </div>
+    </nav>
+</footer>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -7,20 +7,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="Tableau open source projects, APIs, documentation and samples hosted on GitHub.">
 
-<!-- OneTrust -->
-<script
-  src="https://a.sfdcstatic.com/enterprise/tableau/prod/2024012/v1/oneTrust/scripttemplates/otSDKStub.js"
-  data-domain-script="2d08f29e-0ede-4e8c-997c-f7ef5be8d4e7"
-  type="text/javascript"
-  charset="UTF-8"
-></script>
+<!-- OptanonConsentNoticeStart -->
+<script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="019321c1-4b7e-7313-9372-ddbd938f50ea" ></script>
 <script type="text/javascript">
-  function OptanonWrapper() {
-    window.addEventListener('load', () => {
-      window.dataLayer.push( { event: 'OneTrustGroupsUpdated' } );
-    });
-  }
+function OptanonWrapper() { }
 </script>
+<!-- OptanonConsentNoticeEnd -->
 
 
 


### PR DESCRIPTION
@bcantoni   - I added a footer to this page so we could implement the cookie manager. Looks like it all works in my local build. I published the script from the OneTrust app for both production and test. The script here is for the production version. I don't know if we need to do a separate test of the test script. Also, I've merging this the the `master` branch. The `dev` branch is slightly behind. We should probably reconcile these. 